### PR TITLE
util.getHost fails if url has a hyphen

### DIFF
--- a/src/background/util.js
+++ b/src/background/util.js
@@ -14,7 +14,7 @@ var validity = (function(validity) {
 	util.getHost = function(url) {
 		var host,
 			backRefs = [],
-			hostRegExp = new RegExp(/^https?\:\/\/([\.a-zA-Z0-9]+)/);
+			hostRegExp = new RegExp(/^https?\:\/\/([\.a-zA-Z0-9-]+)/);
 
 		//	Host is the first back reference
 		backRefs = hostRegExp.exec(url);


### PR DESCRIPTION
> validity.util.getHost("http://www.example.com/")
> www.example.com
> 
> validity.util.getHost("http://www.example-example.com/")
> www.example

(after fix)

> validity.util.getHost("http://www.example-example.com/")
> www.example-example.com
