### PR TITLE
SyntaxError when W3C response contains a newline.

### DIFF
--- a/src/validity.js
+++ b/src/validity.js
@@ -88,7 +88,8 @@
 				message = messages[i];
 				toEval += 'console.';
 				toEval += message.type;
-				toEval += '(\'line ' + message.lastLine + ': ' + message.message;
+				toEval += '(\'line ' + message.lastLine;
+				toEval += ': ' + message.message.replace(/\r\n|\n|\r/g, '');
 				toEval += '\');';
 			}
 


### PR DESCRIPTION
A SyntaxError is generated in _logMessages when a W3C response contains an end-of-line character. 

This situation occurs when an ill-formed attribute tag contains an end-of-line character.

Error in event handler for 'undefined': SyntaxError: Unexpected token ILLEGAL
    at _logMessages (chrome-extension://bbicmjjbohdfglopkidebfccilipgeif/validity.js:95:8)
    at chrome-extension://bbicmjjbohdfglopkidebfccilipgeif/validity.js:108:6
    at [object Object].dispatch (chrome/EventBindings:181:28)
    at chrome/RendererExtensionBindings:91:24
    at [object Object].dispatch (chrome/EventBindings:181:28)
    at Object.<anonymous> (chrome/RendererExtensionBindings:141:22)
